### PR TITLE
Session refactoring

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,37 +1,22 @@
 class SessionsController < ApplicationController
 
   def create
-    session[:user_id] = user.id
+    user_session.create
+    flash[:notice] = "Signed in!"
 
-    redirect_to root_url, notice: 'Signed in!'
+    redirect_to root_url
   end
 
   def destroy
-    session[:user_id] = nil
+    user_session.destroy
+    flash[:notice] = "Signed out!"
 
-    redirect_to root_url, notice: 'Signed out!'
+    redirect_to root_url
   end
 
   private
 
-  def user
-    find_user || create_user
-  end
-
-  def find_user
-    User.find_by(github_user_id: auth.user_id)
-  end
-
-  def create_user
-    User.create(
-      github_user_id: auth.user_id,
-      nickname:       auth.nickname,
-      email:          auth.email,
-      auth_token:     auth.token
-    )
-  end
-
-  def auth
-    @auth ||= GithubAuth.new(request.env['omniauth.auth'])
+  def user_session
+    @user_session ||= Session.new(request)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,6 @@
 class SessionsController < ApplicationController
+
   def create
-    auth = request.env['omniauth.auth']
-
-    user = User.find_by(github_user_id: auth['uid']) || create_user(auth)
-
     session[:user_id] = user.id
 
     redirect_to root_url, notice: 'Signed in!'
@@ -11,15 +8,30 @@ class SessionsController < ApplicationController
 
   def destroy
     session[:user_id] = nil
+
     redirect_to root_url, notice: 'Signed out!'
   end
 
   private
 
-  def create_user(auth)
-    User.create(github_user_id: auth['uid'],
-                nickname: auth['info']['nickname'],
-                email:  auth['info']['email'],
-                auth_token: auth['credentials']['token'])
+  def user
+    find_user || create_user
+  end
+
+  def find_user
+    User.find_by(github_user_id: auth_data['uid'])
+  end
+
+  def create_user
+    User.create(
+      github_user_id: auth_data['uid'],
+      nickname:       auth_data['info']['nickname'],
+      email:          auth_data['info']['email'],
+      auth_token:     auth_data['credentials']['token']
+    )
+  end
+
+  def auth_data
+    request.env['omniauth.auth']
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,19 +19,19 @@ class SessionsController < ApplicationController
   end
 
   def find_user
-    User.find_by(github_user_id: auth_data['uid'])
+    User.find_by(github_user_id: auth.user_id)
   end
 
   def create_user
     User.create(
-      github_user_id: auth_data['uid'],
-      nickname:       auth_data['info']['nickname'],
-      email:          auth_data['info']['email'],
-      auth_token:     auth_data['credentials']['token']
+      github_user_id: auth.user_id,
+      nickname:       auth.nickname,
+      email:          auth.email,
+      auth_token:     auth.token
     )
   end
 
-  def auth_data
-    request.env['omniauth.auth']
+  def auth
+    @auth ||= GithubAuth.new(request.env['omniauth.auth'])
   end
 end

--- a/app/models/github_auth.rb
+++ b/app/models/github_auth.rb
@@ -1,0 +1,35 @@
+class GithubAuth
+
+  attr_reader :data
+
+  def initialize(data)
+    @data = data
+  end
+
+  def user_id
+    data.fetch('uid')
+  end
+
+  def nickname
+    info.fetch('nickname')
+  end
+
+  def email
+    info.fetch('email')
+  end
+
+  def token
+    credentials.fetch('token')
+  end
+
+
+  private
+
+  def info
+    data.fetch('info')
+  end
+
+  def credentials
+    data.fetch('credentials')
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,41 @@
+class Session
+
+  def initialize(request)
+    @request = request
+  end
+
+  def create
+    session[:user_id] = user.id
+  end
+
+  def destroy
+    session[:user_id] = nil
+  end
+
+  private
+
+  attr_reader :request
+
+  delegate :session, to: :request
+
+  def user
+    @user ||= (find_user || create_user)
+  end
+
+  def find_user
+    User.find_by(github_user_id: auth.user_id)
+  end
+
+  def create_user
+    User.create(
+      github_user_id: auth.user_id,
+      nickname:       auth.nickname,
+      email:          auth.email,
+      auth_token:     auth.token
+    )
+  end
+
+  def auth
+    @auth ||= GithubAuth.new(request.env['omniauth.auth'])
+  end
+end

--- a/spec/models/github_auth_spec.rb
+++ b/spec/models/github_auth_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe GithubAuth do
+
+  let(:omniauth_data) do
+    {
+      "uid"  => "123",
+      "info" => {
+        "nickname" => "batsman",
+        "email"    => "batsman@host.com" 
+      },
+      "credentials" => {
+        "token" => "abc"
+      }
+    }
+  end
+
+  subject { described_class.new(omniauth_data) }
+
+  describe "#user_id" do
+    it "returns the user id" do
+      expect(subject.user_id).to eq("123")
+    end
+  end
+
+  describe "#nickname" do
+    it "returns the user nickname" do
+      expect(subject.nickname).to eq("batsman")
+    end
+  end
+
+  describe "#email" do
+    it "returns the user email" do
+      expect(subject.email).to eq("batsman@host.com")
+    end
+  end
+
+  describe "#token" do
+    it "returns the user token" do
+      expect(subject.token).to eq("abc")
+    end
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe Session do
+  let(:auth)    { double("GithubAuth") }
+  let(:session) { double("ActionDispatch::Request::Session") }
+
+  let(:request) do
+    double(
+      "ActionDispatch::Request",
+      session: session,
+      env:     {}
+    )
+  end
+
+  subject { described_class.new(request) }
+
+  before do
+    allow(GithubAuth).to receive(:new) { auth }
+  end
+
+  describe "#create" do
+    context "for an exisiting user" do
+      let(:user) { FactoryGirl.create(:user) }
+
+      before do
+        allow(auth).to receive(:user_id) { user.github_user_id }
+      end
+
+      it "sets the user session" do
+        expect(session).to receive(:[]=).with(:user_id, user.id)
+
+        subject.create
+      end
+    end
+
+    context "for a new user" do
+      before do
+        {
+          user_id:  "1batsman",
+          nickname: "batsman",
+          email:    "batsman@host.com",
+          token:    "abc"
+        }.each do |attr, val|
+          allow(auth).to receive(attr) { val }
+        end
+      end
+
+      it "creates a new user to the session" do
+        expect(session).to receive(:[]=)
+
+        expect {
+          subject.create
+        }.to change {
+          User.count
+        }.by(1)
+      end
+    end
+  end
+
+  describe "#destroy" do
+    it "clears the user session" do
+      expect(session).to receive(:[]=).with(:user_id, nil)
+
+      subject.destroy
+    end
+  end
+end


### PR DESCRIPTION
General refactoring for the `SessionsController` to move logic out to unit tested objects:

- `GithubAuth` wrapper for omniauth payload
- `Session` maybe better as `UserSession`?  provides actions to create and destroy a user session

